### PR TITLE
fix: decorators ordering problem

### DIFF
--- a/ioa_observe/sdk/decorators/__init__.py
+++ b/ioa_observe/sdk/decorators/__init__.py
@@ -21,6 +21,7 @@ def task(
     name: Optional[str] = None,
     description: Optional[str] = None,
     version: Optional[int] = None,
+    protocol: Optional[str] = None,
     method_name: Optional[str] = None,
     tlp_span_kind: Optional[ObserveSpanKindValues] = ObserveSpanKindValues.TASK,
 ) -> Callable[[F], F]:
@@ -29,6 +30,7 @@ def task(
             name=name,
             description=description,
             version=version,
+            protocol=protocol,
             tlp_span_kind=tlp_span_kind,
         )
     else:
@@ -36,6 +38,7 @@ def task(
             name=name,
             description=description,
             version=version,
+            protocol=protocol,
             method_name=method_name,
             tlp_span_kind=tlp_span_kind,
         )
@@ -45,6 +48,7 @@ def workflow(
     name: Optional[str] = None,
     description: Optional[str] = None,
     version: Optional[int] = None,
+    protocol: Optional[str] = None,
     method_name: Optional[str] = None,
     tlp_span_kind: Optional[
         Union[ObserveSpanKindValues, str]
@@ -57,6 +61,7 @@ def workflow(
                 name=name,
                 description=description,
                 version=version,
+                protocol=protocol,
                 method_name=method_name,
                 tlp_span_kind=tlp_span_kind,
             )(target)
@@ -66,6 +71,7 @@ def workflow(
                 name=name,
                 description=description,
                 version=version,
+                protocol=protocol,
                 tlp_span_kind=tlp_span_kind,
             )(target)
 
@@ -77,14 +83,18 @@ def graph(
     description: Optional[str] = None,
     version: Optional[int] = None,
     method_name: Optional[str] = None,
+    protocol: Optional[str] = None,
 ) -> Callable[[F], F]:
     if method_name is None:
-        return entity_method(name=name, version=version, tlp_span_kind="graph")
+        return entity_method(
+            name=name, version=version, protocol=protocol, tlp_span_kind="graph"
+        )
     else:
         return entity_class(
             name=name,
             version=version,
             method_name=method_name,
+            protocol=protocol,
             tlp_span_kind="graph",
         )
 
@@ -93,12 +103,14 @@ def agent(
     name: Optional[str] = None,
     description: Optional[str] = None,
     version: Optional[int] = None,
+    protocol: Optional[str] = None,
     method_name: Optional[str] = None,
 ) -> Callable[[F], F]:
     return workflow(
         name=name,
         description=description,
         version=version,
+        protocol=protocol,
         method_name=method_name,
         tlp_span_kind=ObserveSpanKindValues.AGENT,
     )

--- a/ioa_observe/sdk/decorators/base.py
+++ b/ioa_observe/sdk/decorators/base.py
@@ -7,7 +7,7 @@ import traceback
 from functools import wraps
 import os
 import types
-from typing import Optional, TypeVar, Callable, Awaitable, Any, cast, Union, Annotated
+from typing import Optional, TypeVar, Callable, Awaitable, Any, Union
 import inspect
 
 from ioa_observe.sdk.decorators.helpers import (

--- a/ioa_observe/sdk/decorators/base.py
+++ b/ioa_observe/sdk/decorators/base.py
@@ -666,15 +666,15 @@ def _handle_execution_result(span, success):
 
 def _handle_graph_response(span, res, protocol, tlp_span_kind):
     if tlp_span_kind == "graph":
+        if protocol:
+            protocol = protocol.upper()
+            span.set_attribute("gen_ai.ioa.graph.protocol", protocol)
         # Check if the response is a Llama Index Workflow object
         graph = determine_workflow_type(res)
         if graph is not None:
             # Convert the graph to JSON string
             graph_json = json.dumps(graph, indent=2)
             span.set_attribute("gen_ai.ioa.graph", graph_json)
-            if protocol:
-                span.set_attribute("gen_ai.ioa.graph.protocol", protocol)
-
             # get graph dynamism
             dynamism = topology_dynamism(graph)
             span.set_attribute("gen_ai.ioa.graph_dynamism", dynamism)

--- a/ioa_observe/sdk/decorators/base.py
+++ b/ioa_observe/sdk/decorators/base.py
@@ -7,7 +7,7 @@ import traceback
 from functools import wraps
 import os
 import types
-from typing import Optional, TypeVar, Callable, Awaitable, Any, cast, Union
+from typing import Optional, TypeVar, Callable, Awaitable, Any, cast, Union, Annotated
 import inspect
 
 from ioa_observe.sdk.decorators.helpers import (
@@ -285,13 +285,23 @@ def _cleanup_span(span, ctx_token):
     context_api.detach(ctx_token)
 
 
+def _unwrap_structured_tool(fn):
+    # Unwraps StructuredTool or similar wrappers to get the underlying function
+    if hasattr(fn, "func") and callable(fn.func):
+        return fn.func
+    return fn
+
+
 def entity_method(
     name: Optional[str] = None,
     description: Optional[str] = None,
     version: Optional[int] = None,
+    protocol: Optional[str] = None,
     tlp_span_kind: Optional[ObserveSpanKindValues] = ObserveSpanKindValues.TASK,
 ) -> Callable[[F], F]:
     def decorate(fn: F) -> F:
+        # Unwrap StructuredTool if present
+        fn = _unwrap_structured_tool(fn)
         is_async = _is_async_method(fn)
         entity_name = name or _get_original_function_name(fn)
         if is_async:
@@ -367,7 +377,7 @@ def entity_method(
                                     agent_recovery_tracker.record_agent_recovery(
                                         entity_name
                                     )
-                        _handle_graph_response(span, res, tlp_span_kind)
+                        _handle_graph_response(span, res, protocol, tlp_span_kind)
                         # span will be ended in the generator
                         if isinstance(res, types.GeneratorType):
                             return _handle_generator(span, res)
@@ -413,7 +423,7 @@ def entity_method(
                         _cleanup_span(span, ctx_token)
                     return res
 
-                return cast(F, async_wrap)
+            decorated = async_wrap
         else:
 
             @wraps(fn)
@@ -477,7 +487,7 @@ def entity_method(
                                 agent_recovery_tracker.record_agent_recovery(
                                     entity_name
                                 )
-                    _handle_graph_response(span, res, tlp_span_kind)
+                    _handle_graph_response(span, res, protocol, tlp_span_kind)
 
                     # span will be ended in the generator
                     if isinstance(res, types.GeneratorType):
@@ -524,7 +534,12 @@ def entity_method(
                     _cleanup_span(span, ctx_token)
                 return res
 
-            return cast(F, sync_wrap)
+            decorated = sync_wrap
+        # # If the original fn was a StructuredTool, re-wrap
+        if hasattr(fn, "func") and callable(fn.func):
+            fn.func = decorated
+            return fn
+        return decorated
 
     return decorate
 
@@ -533,6 +548,7 @@ def entity_class(
     name: Optional[str],
     description: Optional[str],
     version: Optional[int],
+    protocol: Optional[str],
     method_name: Optional[str],
     tlp_span_kind: Optional[ObserveSpanKindValues] = ObserveSpanKindValues.TASK,
 ):
@@ -577,16 +593,18 @@ def entity_class(
             if hasattr(cls, method_to_wrap):
                 original_method = getattr(cls, method_to_wrap)
                 # Only wrap actual functions defined in this class
-                if inspect.isfunction(original_method):
+                unwrapped_method = _unwrap_structured_tool(original_method)
+                if inspect.isfunction(unwrapped_method):
                     try:
                         # Verify the method has a proper signature
-                        sig = inspect.signature(original_method)
+                        sig = inspect.signature(unwrapped_method)
                         wrapped_method = entity_method(
                             name=f"{task_name}.{method_to_wrap}",
                             description=description,
                             version=version,
+                            protocol=protocol,
                             tlp_span_kind=tlp_span_kind,
-                        )(original_method)
+                        )(unwrapped_method)
                         # Set the wrapped method on the class
                         setattr(cls, method_to_wrap, wrapped_method)
                     except Exception:
@@ -646,7 +664,7 @@ def _handle_execution_result(span, success):
     return
 
 
-def _handle_graph_response(span, res, tlp_span_kind):
+def _handle_graph_response(span, res, protocol, tlp_span_kind):
     if tlp_span_kind == "graph":
         # Check if the response is a Llama Index Workflow object
         graph = determine_workflow_type(res)
@@ -654,6 +672,8 @@ def _handle_graph_response(span, res, tlp_span_kind):
             # Convert the graph to JSON string
             graph_json = json.dumps(graph, indent=2)
             span.set_attribute("gen_ai.ioa.graph", graph_json)
+            if protocol:
+                span.set_attribute("gen_ai.ioa.graph.protocol", protocol)
 
             # get graph dynamism
             dynamism = topology_dynamism(graph)

--- a/ioa_observe/sdk/decorators/util.py
+++ b/ioa_observe/sdk/decorators/util.py
@@ -13,7 +13,7 @@ from llama_index.core.workflow.utils import (
 )
 
 
-def _serialize_object(obj, max_depth=5, current_depth=0):
+def _serialize_object(obj, max_depth=3, current_depth=0):
     """
     Intelligently serialize an object to a more meaningful representation
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ioa-observe-sdk"
-version = "1.0.13"
+version = "1.0.14"
 description = "IOA Observability SDK"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -21,17 +21,17 @@ dependencies = [
     "opentelemetry-exporter-otlp-proto-http==1.33.1",
     "opentelemetry-instrumentation",
     "opentelemetry-instrumentation-logging==0.54b1",
-    "opentelemetry-instrumentation-openai==0.40.8",
-    "opentelemetry-instrumentation-llamaindex==0.40.8",
-    "opentelemetry-instrumentation-ollama==0.40.8",
-    "opentelemetry-instrumentation-anthropic==0.40.8",
-    "opentelemetry-instrumentation-langchain==0.40.8",
+    "opentelemetry-instrumentation-openai==0.43.1",
+    "opentelemetry-instrumentation-llamaindex==0.43.1",
+    "opentelemetry-instrumentation-ollama==0.43.1",
+    "opentelemetry-instrumentation-anthropic==0.43.1",
+    "opentelemetry-instrumentation-langchain==0.43.1",
     "opentelemetry-instrumentation-threading==00.54b1",
     "opentelemetry-instrumentation-urllib3==0.54b1",
     "opentelemetry-proto==1.33.1",
     "opentelemetry-sdk==1.33.1",
     "opentelemetry-semantic-conventions==0.54b1",
-    "opentelemetry-semantic-conventions-ai==0.4.9",
+    "opentelemetry-semantic-conventions-ai>=0.4.11",
     "opentelemetry-util-http==0.54b1",
     "langgraph>=0.3.2",
     "langchain>=0.3.19",

--- a/uv.lock
+++ b/uv.lock
@@ -684,7 +684,7 @@ wheels = [
 
 [[package]]
 name = "ioa-observe-sdk"
-version = "1.0.13"
+version = "1.0.14"
 source = { editable = "." }
 dependencies = [
     { name = "colorama" },
@@ -731,18 +731,18 @@ requires-dist = [
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = "==1.33.1" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = "==1.33.1" },
     { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-instrumentation-anthropic", specifier = "==0.40.8" },
-    { name = "opentelemetry-instrumentation-langchain", specifier = "==0.40.8" },
-    { name = "opentelemetry-instrumentation-llamaindex", specifier = "==0.40.8" },
+    { name = "opentelemetry-instrumentation-anthropic", specifier = "==0.43.1" },
+    { name = "opentelemetry-instrumentation-langchain", specifier = "==0.43.1" },
+    { name = "opentelemetry-instrumentation-llamaindex", specifier = "==0.43.1" },
     { name = "opentelemetry-instrumentation-logging", specifier = "==0.54b1" },
-    { name = "opentelemetry-instrumentation-ollama", specifier = "==0.40.8" },
-    { name = "opentelemetry-instrumentation-openai", specifier = "==0.40.8" },
+    { name = "opentelemetry-instrumentation-ollama", specifier = "==0.43.1" },
+    { name = "opentelemetry-instrumentation-openai", specifier = "==0.43.1" },
     { name = "opentelemetry-instrumentation-threading", specifier = "==0.54b1" },
     { name = "opentelemetry-instrumentation-urllib3", specifier = "==0.54b1" },
     { name = "opentelemetry-proto", specifier = "==1.33.1" },
     { name = "opentelemetry-sdk", specifier = "==1.33.1" },
     { name = "opentelemetry-semantic-conventions", specifier = "==0.54b1" },
-    { name = "opentelemetry-semantic-conventions-ai", specifier = "==0.4.9" },
+    { name = "opentelemetry-semantic-conventions-ai", specifier = ">=0.4.11" },
     { name = "opentelemetry-util-http", specifier = "==0.54b1" },
     { name = "pytest" },
     { name = "pytest-vcr" },
@@ -1692,7 +1692,7 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-instrumentation-anthropic"
-version = "0.40.8"
+version = "0.43.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -1700,14 +1700,14 @@ dependencies = [
     { name = "opentelemetry-semantic-conventions" },
     { name = "opentelemetry-semantic-conventions-ai" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/35/74/78219d9e24c18e2f668e78e8af98095d73fc8bc33ca3957e008c35b2e88f/opentelemetry_instrumentation_anthropic-0.40.8.tar.gz", hash = "sha256:679aa497b494f6265ff7a749d4178ccb4683d98fa5dc20a1cca2b01bcfffc150", size = 8969, upload-time = "2025-06-09T00:22:49.669Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/a9/1da3fe7f504de50640164a9533fe2879eff0991a40e6ea5afe7ec6f26f94/opentelemetry_instrumentation_anthropic-0.43.1.tar.gz", hash = "sha256:db79f57e69432e78d6b85e48ae40747a0c188b142cd0c93584a927158ad36f50", size = 11567, upload-time = "2025-07-23T14:39:31.351Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/d8/271783eb64b49adf2ac6decd0ec8131ec05185c3ac98f1d474ad5dd1d73f/opentelemetry_instrumentation_anthropic-0.40.8-py3-none-any.whl", hash = "sha256:c94ea1a40e9eb74700d5af1cf257e744bb5537c9ec3df23579e03d22c859eb66", size = 11509, upload-time = "2025-06-09T00:22:11.575Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fd/5b54fef3c64fb78493a5e9b07292b1c6d0dc0eba8f28840cf933036bf594/opentelemetry_instrumentation_anthropic-0.43.1-py3-none-any.whl", hash = "sha256:2528d434767c76c1597d5fd89f5b03e665750e5bedf7c876614f14a4c7ead298", size = 15164, upload-time = "2025-07-23T14:38:50.333Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-langchain"
-version = "0.40.8"
+version = "0.43.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -1715,14 +1715,14 @@ dependencies = [
     { name = "opentelemetry-semantic-conventions" },
     { name = "opentelemetry-semantic-conventions-ai" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/80/c35a50f412e48fd11fa834b49ace0d331bfa063a0f383e422e1fc94f8575/opentelemetry_instrumentation_langchain-0.40.8.tar.gz", hash = "sha256:26d8fbcc6bb2287f7f103285076ea5e8d3c1c4a6abb97624eb0dc994b0ceb4a6", size = 9330, upload-time = "2025-06-09T00:22:59.353Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/a8/9548000604aff6ef59b9f99a7371161238a59a33f1e5e61fc4f00aae6232/opentelemetry_instrumentation_langchain-0.43.1.tar.gz", hash = "sha256:09d5ed097128015f5a7b553c594e98a3bc8e76ebc32fb1acbca0f8ef2af433d6", size = 13092, upload-time = "2025-07-23T14:39:40.45Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/27/c45f14490f9a89b34090522078a177bdb78cd4bf3dcbf180b6d706274303/opentelemetry_instrumentation_langchain-0.40.8-py3-none-any.whl", hash = "sha256:93d77f6a448ca6dc04f1143431d0d3dd27c36258df1bdb847c82638662da0a1d", size = 10736, upload-time = "2025-06-09T00:22:24.362Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/25/ea96d73d5ba4895d4e19a5e10f26c9344689c6835b5c80f3a7b3bc864a36/opentelemetry_instrumentation_langchain-0.43.1-py3-none-any.whl", hash = "sha256:316e197dad4e86137ac9a7c5e72b3019b460b225319ade32fb5f61d29e3dd663", size = 16776, upload-time = "2025-07-23T14:39:05.342Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-llamaindex"
-version = "0.40.8"
+version = "0.43.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "inflection" },
@@ -1731,9 +1731,9 @@ dependencies = [
     { name = "opentelemetry-semantic-conventions" },
     { name = "opentelemetry-semantic-conventions-ai" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/42/adf522e0f78b2e599268932421c6987cb4be348948098e066e58cd46fea8/opentelemetry_instrumentation_llamaindex-0.40.8.tar.gz", hash = "sha256:aea6042a435212f8aeed1bbfea3423ec89b45fe8c74a92673c194f034ead242d", size = 9397, upload-time = "2025-06-09T00:23:00.247Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/13/c7ca2e0d9aa75216bb6a4d6bc7a6337e32621a1d103896f2dc72556f384c/opentelemetry_instrumentation_llamaindex-0.43.1.tar.gz", hash = "sha256:05323c10144a9caf8bfeff3054cf551b11c51a28b0e49de1dfbf535397d78f5a", size = 12118, upload-time = "2025-07-23T14:39:41.322Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/f5/86ff868658e2ae4f345067ee81b239f51532a908a7d40c738c75dc6b495d/opentelemetry_instrumentation_llamaindex-0.40.8-py3-none-any.whl", hash = "sha256:4cb69d8f01c98a4cd55fbd8a8600f14b373eb4396d89f4f2f31c40eab287a929", size = 16734, upload-time = "2025-06-09T00:22:25.497Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e0/a1b84ca0b9726379d8d90367be1b0d20e99fed008d3bcfb2394d8ebb756e/opentelemetry_instrumentation_llamaindex-0.43.1-py3-none-any.whl", hash = "sha256:5f03e224915e60aa366e6e9e1c6672da5b82cb9182a3989a1ee77eb584b31f6f", size = 21012, upload-time = "2025-07-23T14:39:06.912Z" },
 ]
 
 [[package]]
@@ -1751,7 +1751,7 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-instrumentation-ollama"
-version = "0.40.8"
+version = "0.43.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -1759,14 +1759,14 @@ dependencies = [
     { name = "opentelemetry-semantic-conventions" },
     { name = "opentelemetry-semantic-conventions-ai" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/49/c2/9526ac69c6650b39eb803a4f0372b3ec459f9ca6e8327ae380dd8660ac49/opentelemetry_instrumentation_ollama-0.40.8.tar.gz", hash = "sha256:ec1c1d806471d4c833661bd09ad0db443ef93e7fc59cf84987be2c93835bdbc3", size = 5675, upload-time = "2025-06-09T00:23:05.946Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/d7/9f6ca85b0aac14f8ccfc45425ba247a951f2a94d4c8d0b37398e2fc31db2/opentelemetry_instrumentation_ollama-0.43.1.tar.gz", hash = "sha256:fa4bdc84304d7c00e2f9518a5207716d9fbf1cfc2528d770c647df1dc3b3dc9a", size = 8450, upload-time = "2025-07-23T14:39:45.963Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/2c/c0c3e50fdb4a64f3c6989515c627c241c50f4fa48ba5edc772dc181844f8/opentelemetry_instrumentation_ollama-0.40.8-py3-none-any.whl", hash = "sha256:2c14b508b644d756f5796a39578fb53ac64a6e103ea28820aca29ae6a7f6b613", size = 7188, upload-time = "2025-06-09T00:22:32.388Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/d0/d778997207680b6a566a5fc9fc4b0a14027e576eda1bf4a704115e9a3095/opentelemetry_instrumentation_ollama-0.43.1-py3-none-any.whl", hash = "sha256:2e18e8977eaae9d717da6f825b8b5b68ac558b1091dd95cfa044f2008640835c", size = 10968, upload-time = "2025-07-23T14:39:16.184Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-openai"
-version = "0.40.8"
+version = "0.43.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -1775,9 +1775,9 @@ dependencies = [
     { name = "opentelemetry-semantic-conventions-ai" },
     { name = "tiktoken" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/54/2949b4ffa301c09f0baa2addeb622dcc4b8e2f353903552e8a167929ffac/opentelemetry_instrumentation_openai-0.40.8.tar.gz", hash = "sha256:e151ccdcaae58713693b0ede860511eb560f839fedb34b46c7ccc18cd75da692", size = 15121, upload-time = "2025-06-09T00:23:06.783Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/cf/90675fdf938c67fa362a75f5d26ad83a9982d520ea4f9a8c84e149e93665/opentelemetry_instrumentation_openai-0.43.1.tar.gz", hash = "sha256:73fb071bd1d03481adf33473f784a90101e7a813f742049fb9e5b18c11cef699", size = 23438, upload-time = "2025-07-23T14:39:46.742Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/a3/6d09c4544ab6715b59a549cfc5d72b7e3d357d57aae4b60a25070b1a10c3/opentelemetry_instrumentation_openai-0.40.8-py3-none-any.whl", hash = "sha256:a0b352f6612dd00dba68e6d8bb83029ce6b1162caa74a232eaf0a55e52a8753e", size = 23121, upload-time = "2025-06-09T00:22:33.951Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/d6/e253457cd2739e386a9a6f137091522d085b24239cad8ef2af80840d7959/opentelemetry_instrumentation_openai-0.43.1-py3-none-any.whl", hash = "sha256:7b4d738d7c33b8601bce7db345f16852e7c6e65253c7c23e521d31541362bc74", size = 33543, upload-time = "2025-07-23T14:39:17.995Z" },
 ]
 
 [[package]]
@@ -1851,11 +1851,11 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions-ai"
-version = "0.4.9"
+version = "0.4.11"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8c/ba/2405abde825cf654d09ba16bfcfb8c863156bccdc47d1f2a86df6331e7bb/opentelemetry_semantic_conventions_ai-0.4.9.tar.gz", hash = "sha256:54a0b901959e2de5124384925846bac2ea0a6dab3de7e501ba6aecf5e293fe04", size = 4920, upload-time = "2025-05-16T10:20:54.611Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/8a/9228919e167a03f4c4f4c424a185dbfe62bd8597b9e2b20570b9db85bc84/opentelemetry_semantic_conventions_ai-0.4.11.tar.gz", hash = "sha256:bc84b71c66a01a5836a28104e691c5524f4f677fc90b40a4e6fbc2ec3e250610", size = 4825, upload-time = "2025-07-14T13:32:44.855Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/98/f5196ba0f4105a4790cec8c6671cf676c96dfa29bfedfe3c4f112bf4e6ad/opentelemetry_semantic_conventions_ai-0.4.9-py3-none-any.whl", hash = "sha256:71149e46a72554ae17de46bca6c11ba540c19c89904bd4cc3111aac6edf10315", size = 5617, upload-time = "2025-05-16T10:20:53.062Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a3/eab56cbd9a7d6f7c797172c0600be60811777535fea9c820ede9e985f1c4/opentelemetry_semantic_conventions_ai-0.4.11-py3-none-any.whl", hash = "sha256:9b07da1e66bed1746b61bb5d49d8fba9ae693625ec4ea94ddab390760505bf4b", size = 5682, upload-time = "2025-07-14T13:32:43.877Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

- Ensure we reliably apply the Observe SDK decorator to the `func` only and not to `StructuredTool` object from `Langchain`, regardless of the annotation order.
- Add ability to capture protocol information when annotating with `graph` decorator e.g., SLIM, A2A etc
- Change back the `max_depth` to 3 from 5 when serializing input and output objects

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
