### PR TITLE
feat/attributes transform rules before export

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ This schema is designed to provide comprehensive observability for Multi-Agent S
 
 Link: [AGNTCY Observability Schema](https://github.com/agntcy/observe/blob/main/schema/)
 
+An option is made available for transforming spans attributes exported by using options via env variables (SPAN_TRANSFORMER_RULES_ENABKED, SPAN_TRANSFORMER_RULES_FILE). Please read [transform](./sdk/tracing/transform_span.py).
+
 ## Dev
 
 Any Opentelemetry compatible backend can be used, but for this guide, we will use ClickhouseDB as the backend database.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This schema is designed to provide comprehensive observability for Multi-Agent S
 
 Link: [AGNTCY Observability Schema](https://github.com/agntcy/observe/blob/main/schema/)
 
-An option is made available for transforming spans attributes exported by using options via env variables (SPAN_TRANSFORMER_RULES_ENABKED, SPAN_TRANSFORMER_RULES_FILE). Please read [transform](./sdk/tracing/transform_span.py).
+An option is made available for transforming spans attributes exported by using options via env variables (SPAN_TRANSFORMER_RULES_ENABLED, SPAN_TRANSFORMER_RULES_FILE). Please read [transform](./sdk/tracing/transform_span.py).
 
 ## Dev
 

--- a/ioa_observe/sdk/tracing/transform_span.py
+++ b/ioa_observe/sdk/tracing/transform_span.py
@@ -1,0 +1,210 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+
+def validate_transformer_rules(config):
+    """
+    Validates the transformer rules configuration.
+
+    Args:
+        config (dict): The configuration dictionary to validate.
+
+    Raises:
+        ValueError: If the configuration is invalid.
+
+    Validation rules:
+    - Must have RULES section containing a list of transformation rules
+    - Each rule must have a 'path' field (list of strings)
+    - Path length = 1: Global transformation (e.g., ["old_key"])
+    - Path length > 1: Path-specific transformation
+      (e.g., ["attributes", "nested_key"])
+    - action_conflict must be one of: SKIP, REPLACE, DELETE
+    - DELETE action should not have a 'rename' field
+    """
+    if not isinstance(config, dict):
+        raise ValueError("Configuration must be a dictionary")
+
+    if "RULES" not in config:
+        raise ValueError("Configuration must contain 'RULES' section")
+
+    rules_section = config.get("RULES", [])
+    if not isinstance(rules_section, list):
+        raise ValueError("RULES section must be a list")
+
+    for i, rule in enumerate(rules_section):
+        if not isinstance(rule, dict):
+            raise ValueError(f"Rule {i} must be a dictionary")
+
+        # Check required fields
+        if "path" not in rule:
+            raise ValueError(f"Rule {i} must have 'path' field")
+
+        if not isinstance(rule["path"], list):
+            raise ValueError(f"Rule {i} 'path' must be a list")
+
+        if not rule["path"]:
+            raise ValueError(f"Rule {i} 'path' cannot be empty")
+
+        # Check action_conflict
+        action_conflict = rule.get("action_conflict", "REPLACE")
+        if action_conflict not in ["SKIP", "REPLACE", "DELETE"]:
+            raise ValueError(
+                f"Rule {i} action_conflict must be one of: SKIP, REPLACE, DELETE"
+            )
+
+        # Check rename field for non-DELETE actions
+        if action_conflict != "DELETE" and "rename" not in rule:
+            raise ValueError(
+                f"Rule {i} with {action_conflict} action must have 'rename' field"
+            )
+
+        # Check rename field for DELETE action
+        if action_conflict == "DELETE" and "rename" in rule:
+            raise ValueError(
+                f"Rule {i} with DELETE action should not have 'rename' field"
+            )
+
+
+def transform_json_object_configurable(data, config, current_path=()):
+    """
+    Recursively transforms a JSON object (dict or list) based on a unified
+    configuration that contains transformation rules for both global and
+    path-specific key renames, along with conflict resolution strategies.
+
+    Args:
+        data (dict or list or primitive): The JSON object or part of it
+                                          to transform.
+        config (dict): A dictionary containing transformation rules:
+                       {
+                           "RULES": [
+                               {
+                                   "path": ["old_key"],
+                                   "rename": "new_key",
+                                   "action_conflict": "SKIP"|"REPLACE"|"DELETE"
+                               },
+                               {
+                                   "path": ["attributes",
+                                           "traceloop.span.kind"],
+                                   "rename": "ioa_observe.span_kind",
+                                   "action_conflict": "REPLACE"
+                               },
+                               ...
+                           ]
+                       }
+        current_path (tuple): The current path (sequence of keys) from the
+                              root to the current data element.
+                              Used for path-specific lookups.
+
+    Returns:
+        dict or list or primitive: The transformed JSON object.
+    """
+    if isinstance(data, dict):
+        new_data = {}
+        for key, value in data.items():
+            full_key_path = current_path + (key,)
+
+            # Recursively transform the value first
+            transformed_value = transform_json_object_configurable(
+                value, config, full_key_path
+            )
+
+            # Default to no rename and 'REPLACE' conflict strategy
+            target_new_key = key
+            action_on_conflict = "REPLACE"
+            rule_applied = False
+
+            # Check for matching rules based on path
+            rules = config.get("RULES", [])
+            for rule in rules:
+                rule_path = tuple(rule["path"])
+
+                # Check if this rule applies to the current path
+                if len(rule_path) == 1:
+                    # Global rule: applies if the key matches
+                    if rule_path[0] == key:
+                        action_on_conflict = rule.get("action_conflict", "REPLACE")
+
+                        if action_on_conflict == "DELETE":
+                            # DELETE action: skip adding this key entirely
+                            rule_applied = True
+                            break
+                        elif "rename" in rule:
+                            target_new_key = rule["rename"]
+                            rule_applied = True
+                            break
+                else:
+                    # Path-specific rule: applies if full path matches
+                    if full_key_path == rule_path:
+                        action_on_conflict = rule.get("action_conflict", "REPLACE")
+
+                        if action_on_conflict == "DELETE":
+                            # DELETE action: skip adding this key entirely
+                            rule_applied = True
+                            break
+                        elif "rename" in rule:
+                            target_new_key = rule["rename"]
+                            rule_applied = True
+                            break
+
+            # Skip to next iteration if DELETE action was applied
+            if rule_applied and action_on_conflict == "DELETE":
+                continue
+
+            # Now, decide which key to use in new_data based on rules and
+            # conflict strategy
+            if rule_applied and target_new_key != key:
+                # A rename was proposed
+                if action_on_conflict == "SKIP" and (
+                    target_new_key in data or target_new_key in new_data
+                ):
+                    # If target key already exists in original data OR new_data
+                    # AND action is SKIP, keep the original key and its
+                    # transformed value. The rename is effectively "skipped".
+                    new_data[key] = transformed_value
+                else:
+                    # If action is REPLACE, or target key doesn't exist,
+                    # then perform the rename.
+                    # This will either add a new key or overwrite an
+                    # existing one.
+                    new_data[target_new_key] = transformed_value
+            else:
+                # No rule applied or DELETE handled above
+                new_data[key] = transformed_value
+
+        return new_data
+    elif isinstance(data, list):
+        new_list = []
+        for item in data:
+            # For list items, the path context usually doesn't change
+            # for the elements themselves
+            new_list.append(
+                transform_json_object_configurable(item, config, current_path)
+            )
+        return new_list
+    else:
+        # Base case: primitive types (str, int, float, bool, None)
+        # are returned as is
+        return data
+
+
+def transform_list_of_json_objects_configurable(json_objects_list, config):
+    """
+    Transforms a list of JSON objects by applying key replacements based on
+    the provided unified configuration.
+
+    Args:
+        json_objects_list (list): A list of Python dictionary objects
+                                  (parsed JSON).
+        config (dict): The unified configuration dictionary for
+                       transformations.
+
+    Returns:
+        list: A new list containing the transformed JSON objects.
+    """
+    if not isinstance(json_objects_list, list):
+        raise TypeError("Input must be a list of JSON objects.")
+
+    transformed_list = [
+        transform_json_object_configurable(obj, config) for obj in json_objects_list
+    ]
+    return transformed_list

--- a/tests/test_transform_span.py
+++ b/tests/test_transform_span.py
@@ -1,0 +1,654 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from opentelemetry.context import get_value, attach, Context
+from ioa_observe.sdk.tracing.tracing import session_start
+from ioa_observe.sdk.tracing.transform_span import (
+    transform_json_object_configurable,
+    validate_transformer_rules,
+)
+
+
+class TestTransformSpan(unittest.TestCase):
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.test_rules = {
+            "RULES": [
+                {
+                    "path": ["customsdk.span.kind"],
+                    "rename": "ioa_observe.span_kind",
+                    "action_conflict": "SKIP",
+                },
+                {
+                    "path": ["customsdk.entity.name"],
+                    "rename": "ioa_observe.name",
+                    "action_conflict": "REPLACE",
+                },
+                {
+                    "path": ["attributes", "customsdk.entity.input"],
+                    "rename": "ioa_observe.input",
+                    "action_conflict": "REPLACE",
+                },
+                {
+                    "path": ["details", "nested_data", "customsdk.nested.id"],
+                    "rename": "ioa_observe.nested_id_renamed_by_path",
+                    "action_conflict": "SKIP",
+                },
+            ]
+        }
+
+    def test_transform_json_object_global_rename(self):
+        """Test global key rename functionality."""
+        data = {
+            "customsdk.span.kind": "LLM",
+            "customsdk.entity.name": "test_entity",
+            "other_key": "unchanged",
+        }
+
+        result = transform_json_object_configurable(data, self.test_rules)
+
+        # customsdk.span.kind should be renamed to ioa_observe.span_kind
+        self.assertIn("ioa_observe.span_kind", result)
+        self.assertEqual(result["ioa_observe.span_kind"], "LLM")
+        self.assertNotIn("customsdk.span.kind", result)
+
+        # customsdk.entity.name should be renamed to ioa_observe.name
+        self.assertIn("ioa_observe.name", result)
+        self.assertEqual(result["ioa_observe.name"], "test_entity")
+        self.assertNotIn("customsdk.entity.name", result)
+
+        # other_key should remain unchanged
+        self.assertIn("other_key", result)
+        self.assertEqual(result["other_key"], "unchanged")
+
+    def test_transform_json_object_path_specific_rename(self):
+        """Test path-specific key rename functionality."""
+        data = {
+            "attributes": {
+                "customsdk.entity.input": "test_input",
+                "other_attr": "unchanged",
+            },
+            "details": {
+                "nested_data": {
+                    "customsdk.nested.id": "nested_value",
+                },
+            },
+        }
+
+        result = transform_json_object_configurable(data, self.test_rules)
+
+        # Path-specific rename: attributes.customsdk.entity.input
+        self.assertIn("ioa_observe.input", result["attributes"])
+        self.assertEqual(result["attributes"]["ioa_observe.input"], "test_input")
+        self.assertNotIn("customsdk.entity.input", result["attributes"])
+
+        # Path-specific rename: details.nested_data.customsdk.nested.id
+        nested_data = result["details"]["nested_data"]
+        self.assertIn("ioa_observe.nested_id_renamed_by_path", nested_data)
+        self.assertEqual(nested_data["ioa_observe.nested_id_renamed_by_path"], "nested_value")
+        self.assertNotIn("customsdk.nested.id", result["details"]["nested_data"])
+
+    def test_transform_json_object_conflict_skip(self):
+        """Test SKIP action when target key already exists."""
+        rules = {
+            "RULES": [
+                {
+                    "path": ["old_key"],
+                    "rename": "existing_key",
+                    "action_conflict": "SKIP",
+                },
+            ]
+        }
+
+        # Test with existing_key processed first (should skip rename)
+        data = {
+            "existing_key": "existing_value",
+            "old_key": "old_value",
+        }
+
+        result = transform_json_object_configurable(data, rules)
+
+        # Since action_conflict is SKIP and existing_key is processed first,
+        # old_key should remain unchanged
+        self.assertIn("old_key", result)
+        self.assertEqual(result["old_key"], "old_value")
+        self.assertIn("existing_key", result)
+        self.assertEqual(result["existing_key"], "existing_value")
+
+    def test_transform_json_object_conflict_replace(self):
+        """Test REPLACE action when target key already exists."""
+        rules = {
+            "RULES": [
+                {
+                    "path": ["old_key"],
+                    "rename": "existing_key",
+                    "action_conflict": "REPLACE",
+                },
+            ]
+        }
+
+        # Test with existing_key processed first
+        data = {
+            "existing_key": "existing_value",
+            "old_key": "old_value",
+        }
+
+        result = transform_json_object_configurable(data, rules)
+
+        # Since action_conflict is REPLACE, existing_key should be replaced
+        self.assertNotIn("old_key", result)
+        self.assertIn("existing_key", result)
+        self.assertEqual(result["existing_key"], "old_value")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_session_start_without_env_var(self):
+        """Test session_start with apply_transform=True but no env variable."""
+        with patch("ioa_observe.sdk.tracing.tracing.logging") as mock_logging:
+            session_start(apply_transform=True)
+
+            # Should log error and disable transformation
+            mock_logging.error.assert_called_with(
+                "SPAN_TRANSFORMER_RULES_FILE environment variable not set. "
+                "Disabling transformation."
+            )
+
+    def test_session_start_with_invalid_file(self):
+        """Test session_start with invalid transformer rules file."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", delete=False, suffix=".json"
+        ) as temp_file:
+            temp_file.write("invalid json content")
+            temp_file_path = temp_file.name
+
+        try:
+            with patch.dict(
+                os.environ, {"SPAN_TRANSFORMER_RULES_FILE": temp_file_path}
+            ):
+                with patch("ioa_observe.sdk.tracing.tracing.logging") as mock_logging:
+                    session_start(apply_transform=True)
+
+                    # Should log error about invalid JSON
+                    mock_logging.error.assert_called()
+                    error_call_args = mock_logging.error.call_args[0][0]
+                    self.assertIn("Failed to load transformer rules", error_call_args)
+        finally:
+            os.unlink(temp_file_path)
+
+    def test_session_start_with_valid_rules_file(self):
+        """Test session_start with valid transformer rules file."""
+        # Create test rules in the new unified format
+        valid_test_rules = {
+            "RULES": [
+                {
+                    "path": ["customsdk.span.kind"],
+                    "rename": "ioa_observe.span_kind",
+                    "action_conflict": "REPLACE",
+                },
+            ]
+        }
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", delete=False, suffix=".json"
+        ) as temp_file:
+            json.dump(valid_test_rules, temp_file)
+            temp_file_path = temp_file.name
+
+        try:
+            with patch.dict(
+                os.environ, {"SPAN_TRANSFORMER_RULES_FILE": temp_file_path}
+            ):
+                with patch("ioa_observe.sdk.tracing.tracing.attach"):
+                    with patch(
+                        "ioa_observe.sdk.tracing.tracing.set_value"
+                    ) as mock_set_value:
+                        session_start(apply_transform=True)
+
+                        # Should set apply_transform to True and store rules
+                        mock_set_value.assert_any_call("apply_transform", True)
+                        # Also check that transformer_rules were stored
+                        mock_set_value.assert_any_call(
+                            "transformer_rules", valid_test_rules
+                        )
+        finally:
+            os.unlink(temp_file_path)
+
+    def test_session_start_with_missing_file(self):
+        """Test session_start with non-existent transformer rules file."""
+        non_existent_file = "/path/to/non/existent/file.json"
+
+        with patch.dict(os.environ, {"SPAN_TRANSFORMER_RULES_FILE": non_existent_file}):
+            with patch("ioa_observe.sdk.tracing.tracing.logging") as mock_logging:
+                session_start(apply_transform=True)
+
+                # Should log error about missing file
+                mock_logging.error.assert_called_with(
+                    f"Transformer rules file not found: "
+                    f"{non_existent_file}. Disabling "
+                    f"transformation."
+                )
+
+    def test_session_start_with_invalid_structure(self):
+        """Test session_start with invalid transformer rules structure."""
+        invalid_rules = {
+            "INVALID_SECTION": {},
+            "MISSING_PATH_SPECIFIC": {},
+        }
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", delete=False, suffix=".json"
+        ) as temp_file:
+            json.dump(invalid_rules, temp_file)
+            temp_file_path = temp_file.name
+
+        try:
+            with patch.dict(
+                os.environ, {"SPAN_TRANSFORMER_RULES_FILE": temp_file_path}
+            ):
+                with patch("ioa_observe.sdk.tracing.tracing.logging") as mock_logging:
+                    session_start(apply_transform=True)
+
+                    # Should log error about invalid structure
+                    mock_logging.error.assert_called_with(
+                        "Invalid transformer rules structure. "
+                        "Expected 'RULES' section. "
+                        "Disabling transformation."
+                    )
+        finally:
+            os.unlink(temp_file_path)
+
+    def test_action_delete(self):
+        """Test DELETE action removes keys from the target object."""
+        rules = {
+            "RULES": [
+                {
+                    "path": ["user"],
+                    "action_conflict": "DELETE",
+                },
+                {
+                    "path": ["debug_info"],
+                    "action_conflict": "DELETE",
+                },
+            ]
+        }
+
+        data = {
+            "user": "sensitive_user",
+            "message": "test message",
+            "debug_info": "debug details",
+            "status": "ok",
+        }
+
+        # Transform with DELETE actions
+        result = transform_json_object_configurable(data, rules)
+
+        # Assert deleted keys are removed
+        self.assertNotIn("user", result)
+        self.assertNotIn("debug_info", result)
+
+        # Assert other keys remain
+        self.assertIn("message", result)
+        self.assertIn("status", result)
+        self.assertEqual(result["message"], "test message")
+        self.assertEqual(result["status"], "ok")
+
+    def test_action_delete_with_conflicts(self):
+        """Test DELETE action in combination with other actions."""
+        rules = {
+            "RULES": [
+                {
+                    "path": ["user"],
+                    "action_conflict": "DELETE",
+                },
+                {
+                    "path": ["status"],
+                    "rename": "new_status",
+                    "action_conflict": "REPLACE",
+                },
+            ]
+        }
+
+        data = {
+            "user": "test_user",
+            "status": "original",
+            "message": "test",
+        }
+
+        result = transform_json_object_configurable(data, rules)
+
+        # DELETE removes user key entirely
+        self.assertNotIn("user", result)
+
+        # REPLACE renames status to new_status
+        self.assertNotIn("status", result)
+        self.assertIn("new_status", result)
+        self.assertEqual(result["new_status"], "original")
+
+        # Other keys unchanged
+        self.assertEqual(result["message"], "test")
+
+    def test_validation_rules_valid(self):
+        """Test validation with valid transformer rules."""
+        valid_rules = {
+            "RULES": [
+                {
+                    "path": ["old_key"],
+                    "rename": "new_key",
+                    "action_conflict": "REPLACE",
+                },
+                {
+                    "path": ["test", "path"],
+                    "action_conflict": "DELETE",
+                },
+            ]
+        }
+
+        # Should not raise any exception
+        validate_transformer_rules(valid_rules)
+
+    def test_validation_rules_invalid_structure(self):
+        """Test validation with invalid rule structure."""
+        invalid_rules = {
+            "INVALID_SECTION": {
+                "rule1": {
+                    "rename": "new_key",
+                },
+            }
+        }
+
+        with self.assertRaises(ValueError) as context:
+            validate_transformer_rules(invalid_rules)
+
+        self.assertIn("must contain 'RULES'", str(context.exception))
+
+    def test_validation_rules_invalid_action(self):
+        """Test validation with invalid action_conflict value."""
+        invalid_rules = {
+            "RULES": [
+                {
+                    "path": ["old_key"],
+                    "rename": "new_key",
+                    "action_conflict": "INVALID_ACTION",
+                }
+            ]
+        }
+
+        with self.assertRaises(ValueError) as context:
+            validate_transformer_rules(invalid_rules)
+
+        self.assertIn("must be one of: SKIP, REPLACE, DELETE", str(context.exception))
+
+    def test_validation_rules_delete_with_rename(self):
+        """Test validation where DELETE action has rename field (invalid)."""
+        invalid_rules = {
+            "RULES": [
+                {
+                    "path": ["old_key"],
+                    "rename": "new_key",
+                    "action_conflict": "DELETE",
+                }
+            ]
+        }
+
+        with self.assertRaises(ValueError) as context:
+            validate_transformer_rules(invalid_rules)
+
+        self.assertIn(
+            "DELETE action should not have 'rename' field", str(context.exception)
+        )
+
+    def test_session_start_env_variable_override_true(self):
+        """Test SPAN_TRANSFORMER_RULES_ENABLED overrides
+        apply_transform=False."""
+        # Create a valid transformer rules file
+        temp_file_path = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".json", delete=False
+            ) as temp_file:
+                temp_file_path = temp_file.name
+                rules = {
+                    "RULES": [
+                        {
+                            "path": ["old_key"],
+                            "rename": "new_key",
+                            "action_conflict": "REPLACE",
+                        }
+                    ]
+                }
+                json.dump(rules, temp_file)
+
+            # Test various true values
+            for true_value in ["true", "True", "1"]:
+                with self.subTest(true_value=true_value):
+                    with patch.dict(
+                        os.environ, {"SPAN_TRANSFORMER_RULES_FILE": temp_file_path}
+                    ):
+                        os.environ.update(
+                            {
+                                "SPAN_TRANSFORMER_RULES_FILE": temp_file_path,
+                                "SPAN_TRANSFORMER_RULES_ENABLED": true_value,
+                            }
+                        )
+
+                        # Clear context before test
+                        attach(Context())
+                        # Should be overridden
+                        session_start(apply_transform=False)
+
+                        # Check that transformation is enabled
+                        self.assertTrue(get_value("apply_transform"))
+                        self.assertIsNotNone(get_value("transformer_rules"))
+        finally:
+            if temp_file_path:
+                os.unlink(temp_file_path)
+
+    def test_session_start_env_variable_override_false(self):
+        """Test SPAN_TRANSFORMER_RULES_ENABLED overrides
+        apply_transform=True."""
+        # Test various false values
+        for false_value in ["false", "False", "0"]:
+            with self.subTest(false_value=false_value):
+                with patch.dict(
+                    os.environ, {"SPAN_TRANSFORMER_RULES_ENABLED": false_value}
+                ):
+                    # Clear context before test
+                    attach(Context())
+                    # Should be overridden
+                    session_start(apply_transform=True)
+
+                    # Check that transformation is disabled
+                    self.assertFalse(get_value("apply_transform"))
+
+    def test_session_start_env_variable_invalid_value(self):
+        """Test SPAN_TRANSFORMER_RULES_ENABLED with invalid value."""
+        with patch.dict(
+            os.environ, {"SPAN_TRANSFORMER_RULES_ENABLED": "invalid_value"}
+        ):
+            with patch("ioa_observe.sdk.tracing.tracing.logging") as mock_logging:
+                # Clear context before test
+                attach(Context())
+                session_start(apply_transform=True)
+
+                # Should log error and use original parameter value
+                # Should be called twice:
+                # 1. Invalid env var value
+                # 2. SPAN_TRANSFORMER_RULES_FILE not set
+                self.assertEqual(mock_logging.error.call_count, 2)
+
+                # Check the first error message about invalid env var
+                first_call = mock_logging.error.call_args_list[0][0][0]
+                self.assertIn(
+                    "Invalid SPAN_TRANSFORMER_RULES_ENABLED value", first_call
+                )
+                self.assertIn("Using parameter value: True", first_call)
+
+                # Check the second error message about missing file
+                second_call = mock_logging.error.call_args_list[1][0][0]
+                self.assertIn(
+                    "SPAN_TRANSFORMER_RULES_FILE environment variable not set",
+                    second_call,
+                )
+
+                # Should still use the original parameter value (True)
+                # but transformation gets disabled due to missing file
+                self.assertFalse(get_value("apply_transform"))
+
+    def test_parse_boolean_env_function(self):
+        """Test the _parse_boolean_env helper function."""
+        from ioa_observe.sdk.tracing.tracing import _parse_boolean_env
+
+        # Test true values
+        for true_val in ["true", "True", "1"]:
+            with self.subTest(value=true_val):
+                self.assertTrue(_parse_boolean_env(true_val))
+
+        # Test false values
+        for false_val in ["false", "False", "0"]:
+            with self.subTest(value=false_val):
+                self.assertFalse(_parse_boolean_env(false_val))
+
+        # Test invalid values
+        for invalid_val in ["invalid", "yes", "no", "2", ""]:
+            with self.subTest(value=invalid_val):
+                with self.assertRaises(ValueError) as context:
+                    _parse_boolean_env(invalid_val)
+                self.assertIn(
+                    f"Invalid boolean value: {invalid_val}", str(context.exception)
+                )
+
+    def test_validation_path_specific_structure(self):
+        """Test validation of RULES list structure."""
+        # Test valid structure
+        valid_rules = {
+            "RULES": [
+                {
+                    "path": ["attributes", "test.key"],
+                    "rename": "new.key",
+                    "action_conflict": "REPLACE",
+                },
+            ]
+        }
+        # Should not raise any exception
+        validate_transformer_rules(valid_rules)
+
+    def test_validation_path_specific_missing_path(self):
+        """Test validation when rule missing path field."""
+        invalid_rules = {
+            "RULES": [
+                {
+                    "rename": "new.key",
+                    "action_conflict": "REPLACE",
+                },
+            ]
+        }
+
+        with self.assertRaises(ValueError) as context:
+            validate_transformer_rules(invalid_rules)
+
+        self.assertIn("must have 'path' field", str(context.exception))
+
+    def test_validation_path_specific_invalid_path_type(self):
+        """Test validation when path is not a list."""
+        invalid_rules = {
+            "RULES": [
+                {
+                    "path": "not.a.list",
+                    "rename": "new.key",
+                    "action_conflict": "REPLACE",
+                },
+            ]
+        }
+
+        with self.assertRaises(ValueError) as context:
+            validate_transformer_rules(invalid_rules)
+
+        self.assertIn("'path' must be a list", str(context.exception))
+
+    def test_validation_path_specific_empty_path(self):
+        """Test validation when path is empty."""
+        invalid_rules = {
+            "RULES": [
+                {
+                    "path": [],
+                    "rename": "new.key",
+                    "action_conflict": "REPLACE",
+                },
+            ]
+        }
+
+        with self.assertRaises(ValueError) as context:
+            validate_transformer_rules(invalid_rules)
+
+        self.assertIn("'path' cannot be empty", str(context.exception))
+
+    def test_validation_path_specific_missing_rename_for_non_delete(self):
+        """Test validation when rename field missing for non-DELETE action."""
+        invalid_rules = {
+            "RULES": [
+                {
+                    "path": ["test", "key"],
+                    "action_conflict": "REPLACE",
+                },
+            ]
+        }
+
+        with self.assertRaises(ValueError) as context:
+            validate_transformer_rules(invalid_rules)
+
+        self.assertIn("must have 'rename' field", str(context.exception))
+
+    def test_transform_new_path_specific_structure(self):
+        """Test transformation with unified RULES structure."""
+        rules = {
+            "RULES": [
+                {
+                    "path": ["attributes", "traceloop.span.kind"],
+                    "rename": "ioa_observe.span_kind",
+                    "action_conflict": "REPLACE",
+                },
+                {
+                    "path": ["metadata", "old.field"],
+                    "rename": "new.field",
+                    "action_conflict": "SKIP",
+                },
+            ]
+        }
+
+        data = {
+            "attributes": {
+                "traceloop.span.kind": "LLM",
+                "other_attr": "keep",
+            },
+            "metadata": {
+                "old.field": "value1",
+                "new.field": "existing_value",
+            },
+        }
+
+        result = transform_json_object_configurable(data, rules)
+
+        # Check first path-specific rule (REPLACE)
+        self.assertIn("ioa_observe.span_kind", result["attributes"])
+        self.assertEqual(result["attributes"]["ioa_observe.span_kind"], "LLM")
+        self.assertNotIn("traceloop.span.kind", result["attributes"])
+
+        # Check second path-specific rule (SKIP because target exists)
+        # With SKIP action and target exists, original key should be kept
+        self.assertIn("old.field", result["metadata"])  # Original kept
+        self.assertIn("new.field", result["metadata"])  # Existing kept
+        self.assertEqual(result["metadata"]["new.field"], "existing_value")
+        self.assertEqual(result["metadata"]["old.field"], "value1")
+
+        # Other fields unchanged
+        self.assertIn("other_attr", result["attributes"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Description

Provide methods to apply transformation rules to span attributes before export.

Why? Ensure exported spans comply with a given schema convention for a set of attributes

## Type of Change

- [ ] Bugfix
- [ X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ X] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ X] I have verified this change is not present in other open pull requests
- [ X] Functionality is documented
- [ X] All code style checks pass
- [ X] New code contribution is covered by automated tests
- [ X] All new and existing tests pass
