### PR TITLE
fix: resolve AttributeError around self._wrap_message_with_headers()

### DIFF
--- a/ioa_observe/sdk/instrumentations/slim.py
+++ b/ioa_observe/sdk/instrumentations/slim.py
@@ -94,7 +94,7 @@ class SLIMInstrumentor(BaseInstrumentor):
                 if len(args) > message_arg_index:
                     original_args = list(args)
                     message = original_args[message_arg_index]
-                    wrapped_message = self._wrap_message_with_headers(message, headers)
+                    wrapped_message = SLIMInstrumentor._wrap_message_with_headers(self, message, headers)
 
                     # Convert wrapped message back to bytes if needed
                     if isinstance(wrapped_message, dict):
@@ -149,7 +149,7 @@ class SLIMInstrumentor(BaseInstrumentor):
                 if traceparent and session_id:
                     baggage.set_baggage(f"execution.{traceparent}", session_id)
 
-                wrapped_message = self._wrap_message_with_headers(message, headers)
+                wrapped_message = SLIMInstrumentor._wrap_message_with_headers(self, message, headers)
                 message_to_send = (
                     json.dumps(wrapped_message).encode("utf-8")
                     if isinstance(wrapped_message, dict)
@@ -210,7 +210,7 @@ class SLIMInstrumentor(BaseInstrumentor):
                 if traceparent and session_id:
                     baggage.set_baggage(f"execution.{traceparent}", session_id)
 
-                wrapped_message = self._wrap_message_with_headers(message, headers)
+                wrapped_message = SLIMInstrumentor._wrap_message_with_headers(self, message, headers)
                 message_to_send = (
                     json.dumps(wrapped_message).encode("utf-8")
                     if isinstance(wrapped_message, dict)


### PR DESCRIPTION
# Description

Fix error  `AttributeError: 'Slim' object has no attribute '_wrap_message_with_headers'` when integrating observe-sdk with SLIM v0.4.0.


Example usage of observe-sdk v 1.0.17: https://github.com/agntcy/app-sdk/pull/36/commits/a3e76a034e994920ada95a6448a2b131eb7705c9

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
