### PR TITLE
fix: check and ignore slim v0.6.0+ session instrumentation when older…

### DIFF
--- a/ioa_observe/sdk/instrumentations/slim.py
+++ b/ioa_observe/sdk/instrumentations/slim.py
@@ -478,6 +478,10 @@ class SLIMInstrumentor(BaseInstrumentor):
             slim_bindings.Slim.listen_for_session = instrumented_listen_for_session
 
     def _instrument_session_methods(self, slim_bindings):
+        # check if slim_bindings >= v0.6.0 is installed by looking for Session class
+        if not hasattr(slim_bindings, "Session"):
+            return
+
         # In v0.6.0+, we need to instrument session classes dynamically
         # Try to find session-related classes in the slim_bindings module
         session_classes = []


### PR DESCRIPTION
# Description

Instrumenting slim apps with slim_bindings>=0.4.0 and <0.5.0, I have encountered an error caused by the `_instrument_session_methods` in the slim instrumentation. 

### Steps to reproduce

slim_bindings==0.4.1
ioa-observe-sdk==1.0.22

A call to:
```python
await slim.publish(session_info, message, channel)
```

Raised the exception:

```
.venv/lib/python3.12/site-packages/ioa_observe/sdk/instrumentations/slim.py:909: in _wrap_message_with_headers
    wrapped_message = {"headers": headers, "payload": json.dumps(message)} 

  ...

  Object of type PySessionInfo is not JSON serializable
```

By check in _instrument_session_publish if slim_bindings has a Session object, determining if > 0.6.0, and returning of is, the issue is resolved.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
