### PR TITLE
fix(slim instrumentation): Error when handling publish method of a SessionContext object.

### DIFF
--- a/ioa_observe/sdk/instrumentations/slim.py
+++ b/ioa_observe/sdk/instrumentations/slim.py
@@ -686,7 +686,13 @@ class SLIMInstrumentor(BaseInstrumentor):
                             baggage.set_baggage(f"execution.{traceparent}", session_id)
 
                         # Wrap the message (first argument for publish, second for publish_to)
-                        message_idx = 1 if method_name == "publish_to" else 0
+                        # If the session_class is SessionContext, the message is always in second position
+                        message_idx = (
+                            1
+                            if method_name == "publish_to"
+                            or session_class.__name__ == "SessionContext"
+                            else 0
+                        )
                         if len(args) > message_idx:
                             args_list = list(args)
                             message = args_list[message_idx]


### PR DESCRIPTION
# Description

With SLIM v0.6.0 and higher, the SessionContext class was introduced, and it has publish methods that are instrumented with our SDK. The rule to catch and wrap the message to be sent over SLIM was not applicable and thus we were wrapping the wrong thing. This PR fixes this with a quick workaround: explicit rule for SessionContext methods, as this issue makes applications crash. We could think of better solutions to handle this: as SessionContext methods are only called from a Session object, we could maybe not instrument them.

## Type of Change

- [X] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
