### PR TITLE
fix: slim instrumentation destination param

### DIFF
--- a/ioa_observe/sdk/instrumentations/slim.py
+++ b/ioa_observe/sdk/instrumentations/slim.py
@@ -276,14 +276,14 @@ class SLIMInstrumentor(BaseInstrumentor):
 
             @functools.wraps(original_create_session_async)
             async def wrapped_create_session_async(
-                self, config, dest=None, *args, **kwargs
+                self, config, destination=None, *args, **kwargs
             ):
                 if _global_tracer:
                     with _global_tracer.start_as_current_span(
                         "slim.app.create_session"
                     ) as span:
                         ctx = await original_create_session_async(
-                            self, config, dest, *args, **kwargs
+                            self, config, destination, *args, **kwargs
                         )
                         if hasattr(ctx, "session"):
                             sid = _get_session_id(ctx.session)
@@ -291,7 +291,7 @@ class SLIMInstrumentor(BaseInstrumentor):
                                 span.set_attribute("slim.session.id", sid)
                         return ctx
                 return await original_create_session_async(
-                    self, config, dest, *args, **kwargs
+                    self, config, destination, *args, **kwargs
                 )
 
             App.create_session_async = wrapped_create_session_async
@@ -302,21 +302,21 @@ class SLIMInstrumentor(BaseInstrumentor):
 
             @functools.wraps(original_create_session_and_wait_async)
             async def wrapped_create_session_and_wait_async(
-                self, config, dest=None, *args, **kwargs
+                self, config, destination=None, *args, **kwargs
             ):
                 if _global_tracer:
                     with _global_tracer.start_as_current_span(
                         "slim.app.create_session"
                     ) as span:
                         session = await original_create_session_and_wait_async(
-                            self, config, dest, *args, **kwargs
+                            self, config, destination, *args, **kwargs
                         )
                         sid = _get_session_id(session)
                         if sid:
                             span.set_attribute("slim.session.id", sid)
                         return session
                 return await original_create_session_and_wait_async(
-                    self, config, dest, *args, **kwargs
+                    self, config, destination, *args, **kwargs
                 )
 
             App.create_session_and_wait_async = wrapped_create_session_and_wait_async

--- a/tests/test_manual_instrumentation.py
+++ b/tests/test_manual_instrumentation.py
@@ -10,6 +10,7 @@ import pytest
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_openai import ChatOpenAI
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.semconv._incubating.attributes import gen_ai_attributes as GenAIAttributes
 from opentelemetry.semconv_ai import SpanAttributes
 from opentelemetry.trace import Status, StatusCode, Tracer, TracerProvider
 
@@ -259,7 +260,7 @@ def test_manual_report(exporter_with_custom_span_processor, openai_client):
     assert open_ai_span.attributes[SpanAttributes.LLM_USAGE_TOTAL_TOKENS] is not None
 
     assert (
-        open_ai_span.attributes[SpanAttributes.LLM_USAGE_COMPLETION_TOKENS] is not None
+        open_ai_span.attributes[GenAIAttributes.GEN_AI_USAGE_OUTPUT_TOKENS] is not None
     )
     assert open_ai_span.end_time > open_ai_span.start_time
 

--- a/tests/test_manual_instrumentation.py
+++ b/tests/test_manual_instrumentation.py
@@ -10,7 +10,9 @@ import pytest
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_openai import ChatOpenAI
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
-from opentelemetry.semconv._incubating.attributes import gen_ai_attributes as GenAIAttributes
+from opentelemetry.semconv._incubating.attributes import (
+    gen_ai_attributes as GenAIAttributes,
+)
 from opentelemetry.semconv_ai import SpanAttributes
 from opentelemetry.trace import Status, StatusCode, Tracer, TracerProvider
 

--- a/tests/test_slim_instrumentation.py
+++ b/tests/test_slim_instrumentation.py
@@ -1,0 +1,42 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import types
+from unittest.mock import patch
+
+from ioa_observe.sdk.instrumentations.slim import SLIMInstrumentor
+
+
+def test_create_session_async_accepts_destination_kwarg():
+    captured = {}
+
+    class App:
+        async def create_session_async(self, config, destination=None, *args, **kwargs):
+            captured["destination"] = destination
+
+    fake_bindings = types.SimpleNamespace(App=App)
+
+    with patch("ioa_observe.sdk.instrumentations.slim.TracerWrapper") as tw:
+        tw.return_value.get_tracer.return_value = None
+        SLIMInstrumentor()._instrument_app(fake_bindings)
+
+    asyncio.run(App.create_session_async(App(), "config", destination="dest_name"))
+    assert captured["destination"] == "dest_name"
+
+
+def test_create_session_and_wait_async_accepts_destination_kwarg():
+    captured = {}
+
+    class App:
+        async def create_session_and_wait_async(self, config, destination=None, *args, **kwargs):
+            captured["destination"] = destination
+
+    fake_bindings = types.SimpleNamespace(App=App)
+
+    with patch("ioa_observe.sdk.instrumentations.slim.TracerWrapper") as tw:
+        tw.return_value.get_tracer.return_value = None
+        SLIMInstrumentor()._instrument_app(fake_bindings)
+
+    asyncio.run(App.create_session_and_wait_async(App(), "config", destination="dest_name"))
+    assert captured["destination"] == "dest_name"

--- a/tests/test_slim_instrumentation.py
+++ b/tests/test_slim_instrumentation.py
@@ -29,7 +29,9 @@ def test_create_session_and_wait_async_accepts_destination_kwarg():
     captured = {}
 
     class App:
-        async def create_session_and_wait_async(self, config, destination=None, *args, **kwargs):
+        async def create_session_and_wait_async(
+            self, config, destination=None, *args, **kwargs
+        ):
             captured["destination"] = destination
 
     fake_bindings = types.SimpleNamespace(App=App)
@@ -38,5 +40,7 @@ def test_create_session_and_wait_async_accepts_destination_kwarg():
         tw.return_value.get_tracer.return_value = None
         SLIMInstrumentor()._instrument_app(fake_bindings)
 
-    asyncio.run(App.create_session_and_wait_async(App(), "config", destination="dest_name"))
+    asyncio.run(
+        App.create_session_and_wait_async(App(), "config", destination="dest_name")
+    )
     assert captured["destination"] == "dest_name"


### PR DESCRIPTION
# Description

**1. Fix `destination` parameter in SLIM instrumented wrappers**

The instrumented wrappers for `App.create_session_async` and `App.create_session_and_wait_async` declared their second parameter as `dest`, while the original SLIM API uses `destination`. Callers passing `destination=` as a keyword argument would hit a `TypeError: got multiple values for argument 'destination'` at runtime.

**2. Fix deprecated OTel semconv attribute in test**

The `opentelemetry-semantic-conventions` package renamed `gen_ai.usage.completion_tokens` to `gen_ai.usage.output_tokens`. The OpenAI instrumentation already emits the new attribute (`GEN_AI_USAGE_OUTPUT_TOKENS`), but `test_manual_report` was asserting the old deprecated key (`LLM_USAGE_COMPLETION_TOKENS`), causing a `KeyError` at runtime.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
